### PR TITLE
UKMCAB-2198 UKMCAB-2203 XSS fixes

### DIFF
--- a/src/UKMCAB.Web.UI/Areas/Admin/Controllers/CabManagementController.cs
+++ b/src/UKMCAB.Web.UI/Areas/Admin/Controllers/CabManagementController.cs
@@ -94,10 +94,10 @@ namespace UKMCAB.Web.UI.Areas.Admin.Controllers
         {
             switch (model.SortField)
             {
-                case nameof(CABManagementItemViewModel.Status):
+                case nameof(CABManagementItemViewModel.SubStatus):
                     model.CABManagementItems = model.SortDirection == SortDirectionHelper.Ascending ? 
-                        model.CABManagementItems.OrderBy(cmi => cmi.Status).ThenByDescending(cmi => cmi.LastUpdated).ToList() :
-                        model.CABManagementItems.OrderByDescending(cmi => cmi.Status).ThenByDescending(cmi => cmi.LastUpdated).ToList();
+                        model.CABManagementItems.OrderBy(cmi => cmi.SubStatus).ThenByDescending(cmi => cmi.LastUpdated).ToList() :
+                        model.CABManagementItems.OrderByDescending(cmi => cmi.SubStatus).ThenByDescending(cmi => cmi.LastUpdated).ToList();
                     break;
                 
                 case nameof(CABManagementItemViewModel.CABNumber):

--- a/src/UKMCAB.Web.UI/Areas/Admin/Views/CabManagement/CABManagement.cshtml
+++ b/src/UKMCAB.Web.UI/Areas/Admin/Views/CabManagement/CABManagement.cshtml
@@ -91,7 +91,7 @@
                             }
                             <option value="@nameof(CABManagementItemViewModel.CABNumber)">CAB number</option>
                             <option value="@nameof(CABManagementItemViewModel.LastUpdated)">Last updated</option>
-                            <option value="@nameof(CABManagementItemViewModel.Status)">Status</option>
+                            <option value="@nameof(CABManagementItemViewModel.SubStatus)">Status</option>
                         </select>
                         <input type="hidden" name="sd" id="sortDirection" value="@Model.SortDirection" />
                     </div>

--- a/src/UKMCAB.Web.UI/Areas/Admin/Views/CabManagement/_CabsTable.cshtml
+++ b/src/UKMCAB.Web.UI/Areas/Admin/Views/CabManagement/_CabsTable.cshtml
@@ -1,10 +1,12 @@
+@using System.Net
 @using UKMCAB.Core.Security;
 @using UKMCAB.Data.Models
+@using UKMCAB.Common.Extensions;
 @using UKMCAB.Web.UI.Extensions;
 @using UKMCAB.Web.UI.Models.ViewModels.Admin.CAB;
 @model UKMCAB.Web.UI.Models.ViewModels.Admin.CAB.CABManagementViewModel
 @{
-    var returnUrl = this.Url.ActionContext.HttpContext.Request.GetRequestUri().PathAndQuery;
+    var returnUrl = $"{this.Url.ActionContext.HttpContext.Request.Path}{WebUtility.HtmlEncode(this.Url.ActionContext.HttpContext.Request.QueryString.Value)}";
 }
 
 <table class="govuk-table govuk-!-font-size-16 ukmcab-table">
@@ -36,7 +38,7 @@
                     </th>
                 }
                 <th scope="col" class="govuk-table__header width-one-fifth">
-                    <sort tab-to-show="@Model.TabName" use-serverside-tabs="true" target="@nameof(CABManagementItemViewModel.Status)" sort="@Model.SortField" sort-direction="@Model.SortDirection">Status</sort>
+                    <sort tab-to-show="@Model.TabName" use-serverside-tabs="true" target="@nameof(CABManagementItemViewModel.SubStatus)" sort="@Model.SortField" sort-direction="@Model.SortDirection">Status</sort>
                 </th>
             }
         </tr>
@@ -49,7 +51,7 @@
                 <tr class="govuk-table__row">
                     <td class="govuk-table__cell">
                         <label aria-hidden="true">Cab name</label>
-                        @if (cab.Status == Status.Archived.ToString())
+                        @if (cab.IsPendingApprovalToUnarchive)
                         {
                             <a asp-area="Search" asp-controller="CABProfile" asp-action="Index" asp-route-id="@cab.URLSlug" asp-route-returnUrl="@returnUrl" class="govuk-link govuk-link--no-visited-state">@cab.Name</a>
                         }
@@ -71,7 +73,7 @@
                     {
                         <td class="govuk-table__cell"><label aria-hidden="true">User group</label>@Roles.NameFor(cab.UserGroup)</td>
                     }
-                    <td class="govuk-table__cell"><label aria-hidden="true">Status</label>@cab.Status</td>
+                    <td class="govuk-table__cell"><label aria-hidden="true">Status</label>@cab.SubStatus</td>
                 </tr>
             }
         }

--- a/src/UKMCAB.Web.UI/Areas/Home/Controllers/FeedbackController.cs
+++ b/src/UKMCAB.Web.UI/Areas/Home/Controllers/FeedbackController.cs
@@ -56,7 +56,7 @@ namespace UKMCAB.Web.UI.Areas.Home.Controllers
                 {"date-time", DateTime.UtcNow.ToString("f")},
                 {"what-were-you-doing" , model.WhatWereYouDoing},
                 {"what-went-wrong" , model.WhatWentWrong},
-                {"contact-email-address" , model.Email},
+                {"contact-email-address" , model.Email ?? "Not provided"},
             };
             await _notificationClient.SendEmailAsync(_templateOptions.FeedbackEmail, _templateOptions.FeedbackForm, personalisation);
 

--- a/src/UKMCAB.Web.UI/Areas/Home/Views/Feedback/Success.cshtml
+++ b/src/UKMCAB.Web.UI/Areas/Home/Views/Feedback/Success.cshtml
@@ -1,4 +1,5 @@
-﻿@model UKMCAB.Web.UI.Models.ViewModels.Feedback.FeedbackSuccessViewModel
+﻿@using System.Net
+@model UKMCAB.Web.UI.Models.ViewModels.Feedback.FeedbackSuccessViewModel
 @{
     ViewData["HideFeeback"] = true;
 }
@@ -18,7 +19,7 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Thank you for your feedback</h1>
         <div class="govuk-!-margin-bottom-3">
-            <a class="govuk-link" asp-area="Home" asp-controller="Feedback" asp-action="Submit" asp-route-returnURL="@Model.ReturnURL">Provide more feedback about this page</a>
+            <a class="govuk-link" asp-area="Home" asp-controller="Feedback" asp-action="Submit" asp-route-returnURL="@WebUtility.HtmlEncode(Model.ReturnURL)">Provide more feedback about this page</a>
         </div>
     </div>
 </div>

--- a/src/UKMCAB.Web.UI/Areas/Search/Controllers/UserNoteController.cs
+++ b/src/UKMCAB.Web.UI/Areas/Search/Controllers/UserNoteController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using System.Net;
 using System.Security.Claims;
 using UKMCAB.Core.Security;
 using UKMCAB.Core.Services.CAB;
@@ -95,7 +96,7 @@ public class UserNoteController : Controller
             UserGroup = userNote.UserRole,
             Note = userNote.Note,
             ReturnUrl = Url.IsLocalUrl(returnUrl) ? returnUrl : "/",
-            BackUrl = backUrl,
+            BackUrl = WebUtility.HtmlDecode(backUrl),
             IsOPSSOrInCreatorUserGroup = User.IsInRole(Roles.OPSS.Id) || User.IsInRole(userNote.UserRole),
         };
 

--- a/src/UKMCAB.Web.UI/Areas/Search/Views/CABProfile/Partials/_UserNotes.cshtml
+++ b/src/UKMCAB.Web.UI/Areas/Search/Views/CABProfile/Partials/_UserNotes.cshtml
@@ -1,10 +1,12 @@
 ﻿@using Microsoft.AspNetCore.Http
+@using System.Net
 @using UKMCAB.Web.UI.Models.ViewModels.Shared;
 @model UserNoteListViewModel
 
 @{
     // Note: The returnUrl here is different to the returnUrl passed into the main CAB profile screen.
-    var returnUrl = $"{ViewContext.HttpContext.Request.Path}{ViewContext.HttpContext.Request.QueryString}#usernotes";
+    var returnUrl = $"{ViewContext.HttpContext.Request.Path}{WebUtility.HtmlEncode(ViewContext.HttpContext.Request.QueryString.Value)}#usernotes";
+    returnUrl = returnUrl.Replace("&amp;pagenumber=", "&pagenumber=");
 }
 
 @if (Model.CabHasDraft)
@@ -20,8 +22,7 @@ else
             <h2 class="govuk-heading-l">Government user notes</h2>
         </div>
         <div class="govuk-grid-column-one-quarter">
-            <govuk-button-link class="govuk-button--secondary ukmcab-float__right" asp-area="Search" asp-controller="UserNote" asp-action="Create"
-                               asp-route-cabDocumentId="@Model.CabDocumentId" asp-route-returnUrl="@returnUrl">Add note</govuk-button-link>
+            <govuk-button-link class="govuk-button--secondary ukmcab-float__right" asp-area="Search" asp-controller="UserNote" asp-action="Create" asp-route-cabDocumentId="@Model.CabDocumentId" asp-route-returnUrl="@returnUrl">Add note</govuk-button-link>
         </div>
     </div>
 }

--- a/src/UKMCAB.Web.UI/Areas/Search/Views/UserNote/View.cshtml
+++ b/src/UKMCAB.Web.UI/Areas/Search/Views/UserNote/View.cshtml
@@ -1,9 +1,10 @@
-﻿@using UKMCAB.Core.Security;
+﻿@using System.Net
+@using UKMCAB.Core.Security;
 @using UKMCAB.Web.UI.Areas.Search.Controllers
 @model UKMCAB.Web.UI.Models.ViewModels.Shared.UserNoteViewModel
 
 @{
-    var returnUrl = $"{ViewContext.HttpContext.Request.Path}{ViewContext.HttpContext.Request.QueryString}#usernotes";
+    var backUrl = $"{ViewContext.HttpContext.Request.Path}{WebUtility.HtmlEncode(ViewContext.HttpContext.Request.QueryString.Value)}#usernotes";
 }
 
 @section BackButton
@@ -51,7 +52,7 @@
 
             <div class="govuk-button-group">
                 <a class="govuk-button govuk-button--warning" asp-area="search" asp-controller="UserNote" asp-action="ConfirmDelete"
-                   asp-route-cabDocumentId="@Model.CabDocumentId" asp-route-userNoteId="@Model.Id" asp-route-returnUrl="@Model.ReturnUrl" asp-route-backUrl="@returnUrl">Delete</a>
+                   asp-route-cabDocumentId="@Model.CabDocumentId" asp-route-userNoteId="@Model.Id" asp-route-returnUrl="@Model.ReturnUrl" asp-route-backUrl="@backUrl">Delete</a>
                 <a href="@Model.ReturnUrl" class="govuk-link govuk-link--no-visited-state">Cancel</a>
             </div>
         </div>

--- a/src/UKMCAB.Web.UI/Models/ViewModels/Admin/CAB/CABManagementItemViewModel.cs
+++ b/src/UKMCAB.Web.UI/Models/ViewModels/Admin/CAB/CABManagementItemViewModel.cs
@@ -11,7 +11,8 @@
         public string CABNumber { get; set; }= string.Empty;
         public string? CabNumberVisibility { get; set; }
         public string UKASReference { get; set; } = string.Empty;
-        public string Status { get; set; }= string.Empty;
+        public string SubStatus { get; set; }= string.Empty;
+        public bool IsPendingApprovalToUnarchive { get; set; }
         public DateTime LastUpdated { get; set; }
         public string UserGroup { get; set; }
 
@@ -24,9 +25,13 @@
             CABNumber = doc.CABNumber;
             CabNumberVisibility = doc.CabNumberVisibility;
             UKASReference = doc.UKASReference;
-            Status = doc.SubStatus == SubStatus.None ? "Draft" : doc.SubStatus.GetEnumDescription();
+            SubStatus = doc.SubStatus == Data.Models.SubStatus.None ? "Draft" : doc.SubStatus.GetEnumDescription();
+            IsPendingApprovalToUnarchive = 
+                this.SubStatus == Data.Models.SubStatus.PendingApprovalToUnarchivePublish.GetEnumDescription() || 
+                this.SubStatus == Data.Models.SubStatus.PendingApprovalToUnarchive.GetEnumDescription();
             LastUpdated = doc.LastUpdatedDate;
             UserGroup = doc.CreatedByUserGroup;
+
         }
     }
 }


### PR DESCRIPTION
Cross site vulnerability fixes for Feedback, User notes and CAB management page.

**Feedback**
	fix issue where Email is not allowed to be optional in Non-JavaScript form
	
**User Notes**
	partial view: hack to prevent double encoding of page number parameter in return Url on UserNotes partial view 
	ConfirmDelete action: Html Decode backUrl to prevent double html encoding (Back and Cancel links)

**CAB management page**
	fix issue with (non-rendered) return url link to CAB Profile - it is never rendered because the CABDocument.SubStatus in the if-clause was incorrect.

#UKMCAB-2198 
#UKMCAB-2203 
