### PR TITLE
Implement InitialiseAsync on PostgreCABRepository

### DIFF
--- a/src/UKMCAB.Data/PostgreSQL/PostgreAutoMigration.cs
+++ b/src/UKMCAB.Data/PostgreSQL/PostgreAutoMigration.cs
@@ -16,7 +16,7 @@ public static class PostgreAutoMigration
             throw new ApplicationException($"{nameof(IServiceScopeFactory)} not found");
         }
 
-        using var scope = iServiceScopeFactory.CreateScope();
+        var scope = iServiceScopeFactory.CreateScope();
 
         scope.ServiceProvider.GetRequiredService<ApplicationDataContext>().Database.Migrate();
     }

--- a/src/UKMCAB.Web.UI/Services/ReviewDateReminder/ReviewDateReminderBackgroundService.cs
+++ b/src/UKMCAB.Web.UI/Services/ReviewDateReminder/ReviewDateReminderBackgroundService.cs
@@ -88,7 +88,7 @@ namespace UKMCAB.Web.UI.Services.ReviewDateReminder
         }
         private async Task CheckAndSendReviewDateReminder()
         {
-            using var scope = _scopeFactory.CreateScope();
+            var scope = _scopeFactory.CreateScope();
             var _cabRepository = scope.ServiceProvider.GetRequiredService<ICABRepository>();
 
             var publishedCABs = await _cabRepository.Query<Document>(d => d.StatusValue == Status.Published);
@@ -161,7 +161,7 @@ namespace UKMCAB.Web.UI.Services.ReviewDateReminder
 
         private async Task SendInternalNotificationForCABReviewDateReminderAsync(Document cab, User user, DateTime reviewDate, string url)
         {
-            using var scope = _scopeFactory.CreateScope();
+            var scope = _scopeFactory.CreateScope();
             var _workflowTaskService = scope.ServiceProvider.GetRequiredService<IWorkflowTaskService>();
 
             var personalisation = new Dictionary<string, dynamic?>
@@ -193,7 +193,7 @@ namespace UKMCAB.Web.UI.Services.ReviewDateReminder
         }
         private async Task SendInternalNotificationForLAReviewDateReminderAsync(Document cab, DocumentLegislativeArea LA, User user, string url)
         {
-            using var scope = _scopeFactory.CreateScope();
+            var scope = _scopeFactory.CreateScope();
             var _workflowTaskService = scope.ServiceProvider.GetRequiredService<IWorkflowTaskService>();
 
             var personalisation = new Dictionary<string, dynamic?>


### PR DESCRIPTION
This threw up an exception that:

> Cannot access a disposed context instance. A common cause of this error is disposing a context instance that was resolved from dependency injection and then later trying to use the same context instance elsewhere in your application. This may occur if you are calling 'Dispose' on the context instance, or wrapping it in a using statement. If you are using dependency injection, you should let the dependency injection container take care of disposing context instances. Object name: 'ApplicationDataContext'.

Issue was fixed by removing using statements.