### PR TITLE
UKMCAB-2233: fix to FindAllDocumentsByCABURLAsync, Query

### DIFF
--- a/src/UKMCAB.Core/Services/CAB/CABAdminService.cs
+++ b/src/UKMCAB.Core/Services/CAB/CABAdminService.cs
@@ -67,16 +67,18 @@ namespace UKMCAB.Core.Services.CAB
         public async Task<List<Document>> FindAllDocumentsByCABURLAsync(string url, Status[]? statusesToRetrieve = null)
         {
             List<Document> docs;
+            url = url.ToLower();
+
             if (statusesToRetrieve != null && statusesToRetrieve.Any())
             {
                 docs = await _cabRepository.Query<Document>(d =>
-                    d.URLSlug.Equals(url, StringComparison.CurrentCultureIgnoreCase) &&
+                    d.URLSlug.ToLower().Equals(url) &&
                     statusesToRetrieve.Contains(d.StatusValue));
             }
             else
             {
                 docs = await _cabRepository.Query<Document>(d =>
-                    d.URLSlug.Equals(url, StringComparison.CurrentCultureIgnoreCase));
+                    d.URLSlug.ToLower().Equals(url));
             }
 
             return docs;

--- a/src/UKMCAB.Data/PostgreSQL/Services/CAB/PostgreCABRepository.cs
+++ b/src/UKMCAB.Data/PostgreSQL/Services/CAB/PostgreCABRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq.Dynamic.Core;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
 using UKMCAB.Data.Interfaces.Services.CAB;
 using UKMCAB.Data.Models;
 
@@ -117,10 +118,9 @@ public class PostgreCABRepository : ICABRepository
             // Run query on DocumentPart
             var fullDocs = _dbContext.Set<CABDocumentBlob>()
                 .Where(mappedPredicate)
-                .Select(p => p.CabBlob)
-                .ToList();
+                .Select(p => p.CabBlob);
 
-            return fullDocs.Cast<T>().ToList();
+            return await fullDocs.Cast<T>().ToListAsync();
         }
 
         throw new NotSupportedException("Only Document queries are supported");


### PR DESCRIPTION
No issue was found in the PostgreCABRepository.UpdateAsync function as per the ticket. 

However, an issue was found with the CABAdminService.FindAllDocumentsByCABURLAsync function, which was fixed in this ticket, and a small change also made to PostgreCABRepository.Query