### PR TITLE
UKMCAB-2232: ReviewDateReminder fix + missing timezone on docker

### DIFF
--- a/src/UKMCAB.Core.Tests/Services/Workflow/WorkflowTaskTests.cs
+++ b/src/UKMCAB.Core.Tests/Services/Workflow/WorkflowTaskTests.cs
@@ -81,13 +81,13 @@ public class WorkflowTaskServiceTests
     {
         var task = new WorkflowTask(TaskType.RequestToPublish, userSubmitter,
             forRoleId, userAssigned,
-            DateTime.UtcNow, _faker.Random.Words(), userSubmitter, _faker.Date.Past(), null, null,
+            DateTime.UtcNow, _faker.Random.Words(), userSubmitter, _faker.Date.Past().ToUniversalTime(), null, null,
             completed,
             cabId ?? _faker.Random.Guid(),
             documentLAId ?? _faker.Random.Guid()
         )
         {
-            SentOn = DateTime.Now.AddDays(-1)
+            SentOn = DateTime.UtcNow.AddDays(-1)
         };
         return task;
     }
@@ -124,11 +124,11 @@ public class WorkflowTaskServiceTests
         var newTask = task;
         newTask.Completed = true;
         newTask.Assignee = CreateFakeOpssUser();
-        newTask.Assigned = DateTime.UtcNow.AddDays(-1);
+        newTask.Assigned = DateTime.Now.AddDays(-1);
         newTask.Approved = true;
         newTask.Body = "approved";
         newTask.LastUpdatedBy = CreateFakeOpssUser();
-        newTask.LastUpdatedOn = DateTime.UtcNow;
+        newTask.LastUpdatedOn = DateTime.Now;
         _mockWorkflowTaskRepository.Setup(r => r.ReplaceAsync(It.IsAny<Data.Models.Workflow.WorkflowTask>()))
             .ReturnsAsync(newTask.MapToWorkflowTaskData());
 

--- a/src/UKMCAB.Core/Mappers/WorkflowTaskMapper.cs
+++ b/src/UKMCAB.Core/Mappers/WorkflowTaskMapper.cs
@@ -58,9 +58,9 @@ public static class WorkflowTaskMapper
                 }
                 : null
             ,
-            source.Assigned,
+            source.Assigned?.ToUniversalTime(),
             source.Body,
-            source.SentOn,
+            source.SentOn.ToUniversalTime(),
             new UserAccount
             {
                 Id = source.LastUpdatedBy.UserId,
@@ -69,7 +69,7 @@ public static class WorkflowTaskMapper
                 Role = source.LastUpdatedBy.RoleId,
                 EmailAddress = source.LastUpdatedBy.EmailAddress
             },
-            source.LastUpdatedOn,
+            source.LastUpdatedOn.ToUniversalTime(),
             source.Approved,
             source.DeclineReason,
             source.Completed,

--- a/src/UKMCAB.Core/Services/Workflow/WorkflowTaskService.cs
+++ b/src/UKMCAB.Core/Services/Workflow/WorkflowTaskService.cs
@@ -42,7 +42,7 @@ public class WorkflowTaskService : IWorkflowTaskService
 
     public async Task<List<WorkflowTask>> GetCompletedForRoleIdAsync(string roleId)
     {
-        var items = await _workflowTaskRepository.QueryAsync(w => w.Completed && w.ForRoleId == roleId && w.LastUpdatedOn > DateTime.Now.AddMonths(-6));
+        var items = await _workflowTaskRepository.QueryAsync(w => w.Completed && w.ForRoleId == roleId && w.LastUpdatedOn > DateTime.Now.AddMonths(-6).ToUniversalTime());
         return items.Select(w => w.MapToWorkflowTaskModel()).ToList();
     }
     

--- a/src/UKMCAB.Web.UI/Areas/Admin/Controllers/NotificationController.cs
+++ b/src/UKMCAB.Web.UI/Areas/Admin/Controllers/NotificationController.cs
@@ -87,24 +87,22 @@ public class NotificationController : UI.Controllers.ControllerBase
 
         var skipTake = SkipTake.FromPage(pageNumber - 1, Constants.RowsPerPage);
 
-        var unassignedTask = _workflowTaskService.GetUnassignedByForRoleIdAsync(UserRoleId);
-        var assignedToGroupTask =
-            _workflowTaskService.GetAssignedToGroupForRoleIdAsync(UserRoleId, userId);
-        var completedTask =
-            _workflowTaskService.GetCompletedForRoleIdAsync(UserRoleId);
+        var unassignedTask = await _workflowTaskService.GetUnassignedByForRoleIdAsync(UserRoleId);
+        var assignedToGroupTask = await _workflowTaskService.GetAssignedToGroupForRoleIdAsync(UserRoleId, userId);
+        var completedTask = await _workflowTaskService.GetCompletedForRoleIdAsync(UserRoleId);
 
         Task<List<(string From, string Subject, string? CABName, string? Assignee, DateTime LastUpdated, string? DetailLink)>>
             unAssignedItemsTask =
-                BuildTableItemsAsync(await unassignedTask, sf, sd);
+                BuildTableItemsAsync(unassignedTask, sf, sd);
         Task<List<(string From, string Subject, string? CABName, string? Assignee, DateTime LastUpdated, string? DetailLink)>>
             assignedToMeItemsTask =
                 BuildTableItemsAsync(assignedToMe, sf, sd);
         Task<List<(string From, string Subject, string? CABName, string? Assignee, DateTime LastUpdated, string? DetailLink)>>
             assignedToGroupItemsTask =
-                BuildTableItemsAsync(await assignedToGroupTask, sf, sd);
+                BuildTableItemsAsync(assignedToGroupTask, sf, sd);
         Task<List<(string From, string Subject, string? CABName, string? Assignee, DateTime LastUpdated, string? DetailLink)>>
             completedItemsTask =
-                BuildTableItemsAsync(await completedTask, sf, sd);
+                BuildTableItemsAsync(completedTask, sf, sd);
 
         var model = new NotificationsViewModel
         (
@@ -146,7 +144,7 @@ public class NotificationController : UI.Controllers.ControllerBase
                 new MobileSortTableViewModel(sf, SortDirectionHelper.Descending,
                     BuildMobileSortOptions(AssignedToGroupTabName, sf)),
                 AssignedToGroupTabName, $"There are no notifications assigned to another {Roles.NameFor(UserRoleId)} user",
-                (await assignedToGroupTask).Count),
+                (assignedToGroupTask).Count),
             new NotificationsViewModelTable((await completedItemsTask).Any(), sf, SortDirectionHelper.Get(sd),
                 (await completedItemsTask).Skip(skipTake.Skip).Take(skipTake.Take),
                 new PaginationViewModel

--- a/src/UKMCAB.Web.UI/Controllers/ControllerBase.cs
+++ b/src/UKMCAB.Web.UI/Controllers/ControllerBase.cs
@@ -2,6 +2,7 @@
 {
     using Humanizer;
     using System.Security.Claims;
+    using UKMCAB.Core.Extensions;
     using UKMCAB.Core.Security;
     using UKMCAB.Core.Services.Users;
     using UKMCAB.Data.Models.Users;
@@ -17,7 +18,6 @@
 
         public UserAccount CurrentUser => _userService.GetAsync(User.FindFirstValue(ClaimTypes.NameIdentifier)).Result ?? throw new InvalidOperationException();
 
-        //TODO: Why do we need to re-fetch the user object every time we want to check its role?
-        public string UserRoleId => CurrentUser.Role ?? throw new InvalidOperationException();
+        public string UserRoleId => User.GetRoleId() ?? throw new InvalidOperationException();
     }
 }

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -15,6 +15,8 @@ services:
          condition: service_healthy
      networks:
        - app-network
+     environment:
+        - TZ=Europe/London
    ukmcab-db:
      image: postgres:latest
      hostname: ukmcabdb
@@ -23,6 +25,7 @@ services:
       - POSTGRES_DB=ukmcab
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
+      - TZ=Europe/London
      volumes: 
       - ./.containers/audit-db:/var/lib/postgresql/data
      ports:


### PR DESCRIPTION
Fix issue with ReviewDateREminderBackgroundService: 
- save date/time as UTC format 

Fix issues with notifications page: 
1. incompatibility between .NET and PostgreSQL date/time data types: fix search filter criteria to use date/time in UTC format
2. concurrency (locking) issue when accessing the data context to load the user account: fix to load UserRoleId from claims instead of re-loading from database ever time
3. date/time in sent on/updated on column were not being converted to local time - the docker container had no time zone info: fix by adding environment variable to web and db in docker compose.